### PR TITLE
Bitwise expression parser using state machine

### DIFF
--- a/.quasar/client-entry.js
+++ b/.quasar/client-entry.js
@@ -40,6 +40,12 @@ import createApp from './app.js'
 
 
 
+Vue.config.devtools = true
+Vue.config.productionTip = false
+
+
+
+console.info('[Quasar] Running SPA.')
 
 
 

--- a/src/components/editor/vlgMode.js
+++ b/src/components/editor/vlgMode.js
@@ -76,35 +76,37 @@ CodeMirror.registerHelper("fold", "vlg", function(cm, start) {
   };
 });
 
-CodeMirror.registerHelper("lint", "vlg", text => {
-  if (text == "") return [];
-  var found = [];
+// use this code when cmOptions.lint=true.
+// otherwise use lint: {getAnnotations:myValidator} where myValidator(text, updateLinting, options) does the parsing and returns array of errors
+// CodeMirror.registerHelper("lint", "vlg", text => {
+//   if (text == "") return [];
+//   var found = [];
 
-  const parse = vlgParser(text);
+//   const parse = vlgParser(text);
 
-  var finder = lineColumn(text, { origin: 0 });
+//   var finder = lineColumn(text, { origin: 0 });
 
-  const addError = (error, index, severity) => {
-    var errorStart = finder.fromIndex(index);
-    var errorEnd = finder.fromIndex(
-      Math.max(text.regexIndexOf(/[\s\(\)\[\]\{\},=]/, index), index)
-    );
-    found.push({
-      message: error,
-      severity,
-      from: CodeMirror.Pos(errorStart.line, errorStart.col),
-      to: CodeMirror.Pos(errorEnd.line, errorEnd.col)
-    });
-  };
+//   const addError = (error, index, severity) => {
+//     var errorStart = finder.fromIndex(index);
+//     var errorEnd = finder.fromIndex(
+//       Math.max(text.regexIndexOf(/[\s\(\)\[\]\{\},=]/, index), index)
+//     );
+//     found.push({
+//       message: error,
+//       severity,
+//       from: CodeMirror.Pos(errorStart.line, errorStart.col),
+//       to: CodeMirror.Pos(errorEnd.line, errorEnd.col)
+//     });
+//   };
 
-  parse.lint.forEach(x => addError(x.error, x.index, x.severity));
-  if (parse.parseState.isError) {
-    if (parse.lint.length == 0)
-      addError(parse.parseState.error, parse.parseState.index);
-  }
+//   parse.lint.forEach(x => addError(x.error, x.index, x.severity));
+//   if (parse.parseState.isError) {
+//     if (parse.lint.length == 0)
+//       addError(parse.parseState.error, parse.parseState.index);
+//   }
 
-  return found;
-});
+//   return found;
+// });
 
 var dictionary = {
   start: [

--- a/src/components/test.js
+++ b/src/components/test.js
@@ -1,0 +1,236 @@
+const { inspect } = require("util");
+const A = require("arcsecond");
+
+const deepLog = x =>
+  console.log(
+    inspect(x, {
+      depth: Infinity,
+      colors: true
+    })
+  );
+
+const asType = type => value => ({ type, value });
+const mapJoin = parser => parser.map(items => items.join(""));
+const peek = A.lookAhead(A.regex(/^./));
+
+const upperOrLowerStr = s =>
+  A.choice([A.str(s.toUpperCase()), A.str(s.toLowerCase())]);
+
+const binaryOperation = asType("BINARY_OPERATION");
+const disambiguateOrderOfOperations = expr => {
+  if (
+    expr.type !== "SQUARE_BRACKET_EXPRESSION" &&
+    expr.type !== "BRACKETED_EXPRESSION"
+  ) {
+    return expr;
+  }
+
+  if (expr.value.length === 1) {
+    return expr.value[0];
+  }
+
+  const priorities = {
+    OP_MULTIPLY: 2,
+    OP_PLUS: 1,
+    OP_MINUS: 0
+  };
+  let candidateExpression = {
+    priority: -Infinity
+  };
+
+  for (let i = 1; i < expr.value.length; i += 2) {
+    const level = priorities[expr.value[i].type];
+    if (level > candidateExpression.priority) {
+      candidateExpression = {
+        priority: level,
+        a: i - 1,
+        b: i + 1,
+        op: expr.value[i]
+      };
+    }
+  }
+
+  const newExpression = asType("BRACKETED_EXPRESSION")([
+    ...expr.value.slice(0, candidateExpression.a),
+    binaryOperation({
+      a: disambiguateOrderOfOperations(expr.value[candidateExpression.a]),
+      b: disambiguateOrderOfOperations(expr.value[candidateExpression.b]),
+      op: candidateExpression.op
+    }),
+    ...expr.value.slice(candidateExpression.b + 1)
+  ]);
+
+  return disambiguateOrderOfOperations(newExpression);
+};
+
+const register = A.choice([
+  upperOrLowerStr("r1"),
+  upperOrLowerStr("r2"),
+  upperOrLowerStr("r3"),
+  upperOrLowerStr("r4"),
+  upperOrLowerStr("r5"),
+  upperOrLowerStr("r6"),
+  upperOrLowerStr("r7"),
+  upperOrLowerStr("r8"),
+  upperOrLowerStr("sp"),
+  upperOrLowerStr("fp"),
+  upperOrLowerStr("ip"),
+  upperOrLowerStr("acc")
+]).map(asType("REGISTER"));
+
+const hexDigit = A.regex(/^[0-9A-Fa-f]/);
+const hexLiteral = A.char("$")
+  .chain(() => mapJoin(A.many1(hexDigit)))
+  .map(asType("HEX_LITERAL"));
+
+const validIdentifier = mapJoin(
+  A.sequenceOf([
+    A.regex(/^[a-zA-Z_]/),
+    A.possibly(A.regex(/^[a-zA-Z0-9_]+/)).map(x => (x === null ? "" : x))
+  ])
+);
+const variable = A.char("!")
+  .chain(() => validIdentifier)
+  .map(asType("VARIABLE"));
+
+const operator = A.choice([
+  A.char("+").map(asType("OP_PLUS")),
+  A.char("-").map(asType("OP_MINUS")),
+  A.char("*").map(asType("OP_MULTIPLY"))
+]);
+
+const last = a => a[a.length - 1];
+
+const typifyBracketedExpression = expr => {
+  const asBracketed = asType("BRACKETED_EXPRESSION");
+  return asBracketed(
+    expr.map(element => {
+      if (Array.isArray(element)) {
+        return typifyBracketedExpression(element);
+      }
+      return element;
+    })
+  );
+};
+
+const bracketedExpr = A.coroutine(function*() {
+  const states = {
+    OPEN_BRACKET: 0,
+    OPERATOR_OR_CLOSING_BRACKET: 1,
+    ELEMENT_OR_OPENING_BRACKET: 2,
+    CLOSE_BRACKET: 3
+  };
+
+  let state = states.ELEMENT_OR_OPENING_BRACKET;
+
+  const expr = [];
+  const stack = [expr];
+  yield A.char("(");
+
+  while (true) {
+    const nextChar = yield peek;
+
+    if (state === states.OPEN_BRACKET) {
+      yield A.char("(");
+      expr.push([]);
+      stack.push(last(expr));
+      yield A.optionalWhitespace;
+      state = states.ELEMENT_OR_OPENING_BRACKET;
+    } else if (state === states.CLOSE_BRACKET) {
+      yield A.char(")");
+      stack.pop();
+      if (stack.length === 0) {
+        // We've reached the end of the bracket expression
+        break;
+      }
+
+      yield A.optionalWhitespace;
+      state = states.OPERATOR_OR_CLOSING_BRACKET;
+    } else if (state === states.ELEMENT_OR_OPENING_BRACKET) {
+      if (nextChar === ")") {
+        yield A.fail("Unexpected end of expression");
+      }
+
+      if (nextChar === "(") {
+        state = states.OPEN_BRACKET;
+      } else {
+        last(stack).push(yield A.choice([hexLiteral, variable]));
+        yield A.optionalWhitespace;
+        state = states.OPERATOR_OR_CLOSING_BRACKET;
+      }
+    } else if (state === states.OPERATOR_OR_CLOSING_BRACKET) {
+      if (nextChar === ")") {
+        state = states.CLOSE_BRACKET;
+        continue;
+      }
+
+      last(stack).push(yield operator);
+      yield A.optionalWhitespace;
+      state = states.ELEMENT_OR_OPENING_BRACKET;
+    } else {
+      // This shouldn't happen!
+      throw new Error("Unknown state");
+    }
+  }
+  return expr;
+});
+
+const squareBracketExpr = A.coroutine(function*() {
+  yield A.char("[");
+  yield A.optionalWhitespace;
+
+  const states = {
+    EXPECT_ELEMENT: 0,
+    EXPECT_OPERATOR: 1
+  };
+
+  const expr = [];
+  let state = states.EXPECT_ELEMENT;
+
+  while (true) {
+    if (state === states.EXPECT_ELEMENT) {
+      const result = yield A.choice([bracketedExpr, hexLiteral, variable]);
+      expr.push(result);
+      state = states.EXPECT_OPERATOR;
+      yield A.optionalWhitespace;
+    } else if (state === states.EXPECT_OPERATOR) {
+      const nextChar = yield peek;
+      if (nextChar === "]") {
+        yield A.char("]");
+        yield A.optionalWhitespace;
+        break;
+      }
+
+      const result = yield operator;
+      expr.push(result);
+      state = states.EXPECT_ELEMENT;
+      yield A.optionalWhitespace;
+    }
+  }
+
+  deepLog(expr);
+
+  return asType("SQUARE_BRACKET_EXPRESSION")(expr);
+}); //.map(disambiguateOrderOfOperations);
+
+const movLitToReg = A.coroutine(function*() {
+  yield upperOrLowerStr("mov");
+  yield A.whitespace;
+
+  const arg1 = yield A.choice([hexLiteral, squareBracketExpr]);
+
+  yield A.optionalWhitespace;
+  yield A.char(",");
+  yield A.optionalWhitespace;
+
+  const arg2 = yield register;
+  yield A.optionalWhitespace;
+
+  return asType("INSTRUCTION")({
+    instruction: "MOV_LIT_REG",
+    args: [arg1, arg2]
+  });
+});
+// (~A & ~C) | B | (A & C);
+const res = squareBracketExpr.run("[!a * (!b + !c)]");
+deepLog(res);

--- a/src/components/vlgParser.js
+++ b/src/components/vlgParser.js
@@ -213,11 +213,11 @@ const gateParser = coroutine(function*() {
 // Assign parser ======================================================
 
 const operator = choice([
-  char("&").map(asType("OP_AND")),
-  char("|").map(asType("OP_OR")),
-  char("^").map(asType("OP_XOR")),
-  str("~&").map(asType("OP_NAND")),
-  str("~|").map(asType("OP_NOR"))
+  char("&").map(x => ({ type: "OP_AND", value: "and" })),
+  char("|").map(x => ({ type: "OP_OR", value: "or" })),
+  char("^").map(x => ({ type: "OP_XOR", value: "xor" })),
+  str("~&").map(x => ({ type: "OP_NAND", value: "nand" })),
+  str("~|").map(x => ({ type: "OP_NOR", value: "nor" }))
 ]);
 const variable = sequenceOf([
   possibly(char("~")),
@@ -342,7 +342,7 @@ const assignParser = coroutine(function*() {
   const value = yield squareBracketExpr.errorMap(
     lintError("Invalid expression")
   );
-  console.log("assignParser: ", id, value);
+  // console.log("assignParser: ", id, value);
   return { type: "assign", id, value };
 });
 

--- a/src/components/vlgParser.js
+++ b/src/components/vlgParser.js
@@ -156,6 +156,8 @@ const primary = recursiveParser(() =>
   })
 );
 
+// TODO: Need help here - how can we make sequenceOf(expression, binary_operator, expression)??
+// This causes an endloss loop and stack overflow but is needed to have expressions like (A & B) | C | D
 const expression = choice([
   sequenceOf([primary, ws(BINARY_OPERATOR), primary]).map(x => ({
     type: "binaryExpression",

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -14,7 +14,11 @@
             href="https://github.com/dkilfoyle/logic"
             rel="noopener"
             target="_blank"
-            ><q-btn flat icon="img:statics/icons/GitHub-Mark-32px.png"></q-btn
+            ><q-btn
+              flat
+              color="secondary"
+              icon="img:statics/icons/GitHub-Mark-32px.png"
+            ></q-btn
           ></a>
         </div>
       </q-toolbar>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -283,8 +283,8 @@ export default {
       tab: "code",
       layout: "dagre",
       source: { BitAdder, DFF, Scratch, OneHotDecoder, SevenSeg, Mux2_1 },
-      sourceTab: "OneHotDecoder",
-      openFiles: ["OneHotDecoder", "Mux2_1", "Scratch"],
+      sourceTab: "SevenSeg",
+      openFiles: ["OneHotDecoder", "Mux2_1", "Scratch", "SevenSeg"],
       errors: {}
     };
   },

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -217,6 +217,10 @@ const evaluate = (components, componentLookup) => {
         return;
       }
       const aOut = componentLookup[component.inputs[0]];
+      if (!aOut) {
+        console.log(component.inputs[0]);
+        throw new Error("component not found");
+      }
       component.state =
         aOut === "x" ? "x" : logicFunctions[logicFn](aOut.state);
       return;

--- a/src/pages/vlgWalker.js
+++ b/src/pages/vlgWalker.js
@@ -53,17 +53,6 @@ const createInstance = (outputNamespace, instance) => {
 
     if (node.type == "expression") {
       let expr = node.value;
-      if (expr.length < 3)
-        throw new Error("Invalid expression length: must be at least 3");
-      if (
-        !(
-          expr[0].type == "variable" &&
-          expr[1].type == "binaryop" &&
-          expr[2].type == "variable"
-        )
-      )
-        throw new Error("Invalid sequence of expression values");
-
       console.log(" -- " + expr.map(x => x.type + ":" + x.value).join(", "));
 
       // for each operation triplet

--- a/src/statics/files/7seg.vlg
+++ b/src/statics/files/7seg.vlg
@@ -1,5 +1,4 @@
-/* 
-7 segment display decoder
+/* 7 segment display decoder
   a
 f   b
   g
@@ -22,15 +21,13 @@ module SevenSeg(
   input A, B, C,
   output Fa, Fb, Fc, Fd, Fe, Ff, Fg);
 
-  assign Fa = A & (B | ~C);
-
-  //assign Fa = (((~A & ~C) | B) | (A & C));
-  //assign Fb = (((~B & ~C) | ~A) | (B & C));
-  //assign Fc = ((A | ~B) | C);
-  //assign Fd = (((~A & ~C) | (~A & B)) | ((B & ~C) | ((A & ~B) & C)));
-  //assign Fe = ((~A & ~C) | (B & ~C));
-  //assign Ff = (((~B & ~C) | (A & ~C)) | (A & ~B));
-  //assign Fg = (((~A & B) | (A & ~C)) | (A & ~B));
+  assign Fa = (~A & ~C) | B        | (A & C);
+  assign Fb = (~B & ~C) | ~A       | (B & C);
+  assign Fc = A         | ~B       | C;
+  assign Fd = (~A & ~C) | (~A & B) | (B & ~C) | (A & ~B & C);
+  assign Fe = (~A & ~C) | (B & ~C);
+  assign Ff = (~B & ~C) | (A & ~C) | (A & ~B);
+  assign Fg = (~A & B)  | (A & ~C) | (A & ~B);
 endmodule
 
 module main(

--- a/src/statics/files/7seg.vlg
+++ b/src/statics/files/7seg.vlg
@@ -22,17 +22,15 @@ module SevenSeg(
   input A, B, C,
   output Fa, Fb, Fc, Fd, Fe, Ff, Fg);
 
-  assign Fa = (((~A & ~C) | B) | (A & C));
-  assign Fb = (((~B & ~C) | ~A) | (B & C));
-  assign Fc = ((A | ~B) | C);
-  assign Fd = 
-    (
-      ((~A & ~C) | (~A & B)) |
-      ((B & ~C) | ((A & ~B) & C))
-    );
-  assign Fe = ((~A & ~C) | (B & ~C));
-  assign Ff = (((~B & ~C) | (A & ~C)) | (A & ~B));
-  assign Fg = (((~A & B) | (A & ~C)) | (A & ~B));
+  assign Fa = A & (B | ~C);
+
+  //assign Fa = (((~A & ~C) | B) | (A & C));
+  //assign Fb = (((~B & ~C) | ~A) | (B & C));
+  //assign Fc = ((A | ~B) | C);
+  //assign Fd = (((~A & ~C) | (~A & B)) | ((B & ~C) | ((A & ~B) & C)));
+  //assign Fe = ((~A & ~C) | (B & ~C));
+  //assign Ff = (((~B & ~C) | (A & ~C)) | (A & ~B));
+  //assign Fg = (((~A & B) | (A & ~C)) | (A & ~B));
 endmodule
 
 module main(

--- a/src/statics/files/mux.vlg
+++ b/src/statics/files/mux.vlg
@@ -9,18 +9,18 @@ sel a b | F
  1  0 0 | 0
  1  0 1 | 1
  1  1 0 | 0
- 1  1 1 | 1*/
+ 1  1 1 | 1
+ */
 
 module Mux2_1 (
 	input sel,
 	input a, b,
 	output F);
 
-	assign F = ((~sel & a) | (sel & b));
+	assign F = (~sel & a) | (sel & b);
 endmodule
 
 module main(output F);
-
   wire a, b, sel;
 
   control(a);
@@ -28,7 +28,6 @@ module main(output F);
   control(sel);
 
   Mux2_1 mux(.a(a), .b(b), .sel(sel), .F(F));
-
   buffer(F);
 
   test begin

--- a/src/statics/files/mux4.vlg
+++ b/src/statics/files/mux4.vlg
@@ -1,0 +1,43 @@
+/* 4 to 1 Multiplexer using 2 bit select vector
+Sel selects which input to pass to output
+sel  | F
+ 00  | a 
+ 01  | b 
+ 10  | c 
+ 11  | d 
+*/
+
+module Mux4_1 (
+  input [1:0] sel,
+  input a, b, c, d
+  output F);
+
+	assign F = (
+        (((a & ~sel[0]) & ~sel[1]) | ((b & ~sel[0]) &  sel[1])) |
+        (((c &  sel[0]) & ~sel[1]) | ((d &  sel[0]) &  sel[1]))
+  )
+endmodule
+
+module main(output F);
+
+  wire a, b, c, d;
+  wire [1:0] sel;
+
+  control(a);
+  control(b);
+  control(c);
+  control(d);
+  control(sel);
+
+  Mux2_1 mux(.a(a), .b(b), .sel(sel), .F(F));
+
+  buffer(F);
+
+  test begin
+    #02 {sel=2'b00, a=0, b=1, c=0, d=1}; // expect a = 0 
+    #03 {sel=2'b01, a=0, b=1, c=0, d=1}; // expect b = 1 
+    #04 {sel=2'b10, a=0, b=1, c=0, d=1}; // expect c = 0 
+    #05 {sel=2'b11, a=0, b=1, c=0, d=1}; // expect d = 1 
+    #06;
+  end
+endmodule

--- a/src/statics/files/onehotdecoder.vlg
+++ b/src/statics/files/onehotdecoder.vlg
@@ -1,5 +1,4 @@
-/* 
-2 to 4 one hot decoder
+/* 2 to 4 one hot decoder
 a b | F3 F2 F1 F0
 0 0 |  0  0  0  1 
 0 1 |  0  0  1  0
@@ -12,10 +11,10 @@ module OneHotDecoderBitwise (
   input a, b,
   output F3, F2, F1, F0);
 
-  assign F0 = (~a & ~b);
-  assign F1 = (~a & b);
-  assign F2 = (a & ~b);
-  assign F3 = (a & b);
+  assign F0 = ~a & ~b;
+  assign F1 = ~a & b;
+  assign F2 = a & ~b;
+  assign F3 = a & b;
 endmodule
 
 // using standard gate statements

--- a/src/statics/files/onehotdecoder.vlg
+++ b/src/statics/files/onehotdecoder.vlg
@@ -12,10 +12,10 @@ module OneHotDecoderBitwise (
   input a, b,
   output F3, F2, F1, F0);
 
-  assign F0 = (a & b | a);
-  //assign F1 = (~a & b);
-  //assign F2 = (a & ~b);
-  //assign F3 = (a & b);
+  assign F0 = (~a & ~b);
+  assign F1 = (~a & b);
+  assign F2 = (a & ~b);
+  assign F3 = (a & b);
 endmodule
 
 // using standard gate statements

--- a/src/statics/files/onehotdecoder.vlg
+++ b/src/statics/files/onehotdecoder.vlg
@@ -12,10 +12,10 @@ module OneHotDecoderBitwise (
   input a, b,
   output F3, F2, F1, F0);
 
-  assign F0 = (~a & ~b);
-  assign F1 = (~a & b);
-  assign F2 = (a & ~b);
-  assign F3 = (a & b);
+  assign F0 = (a & b | a);
+  //assign F1 = (~a & b);
+  //assign F2 = (a & ~b);
+  //assign F3 = (a & b);
 endmodule
 
 // using standard gate statements

--- a/src/statics/files/scratch.vlg
+++ b/src/statics/files/scratch.vlg
@@ -9,7 +9,7 @@ module MyModule (
   or(  Y, a, b );
 
   // alternative bitwise format
-  // assign X = (a & b);
+  // assign X = a & b;
 endmodule
 
 module main(


### PR DESCRIPTION
For example:
```js
assign F = (~sel & a) | (sel & b);
```
Episode 9 of [LowLevelJavascript 16-bitVM](https://www.youtube.com/watch?v=EaUBBDESWCY) was essential to sort this out.
Verilog does not have defined operator precedence (no disambiguateOperatorPrecedence) so use brackets where needed.